### PR TITLE
[fix] Chinchila was trained on 1.4 T tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ To support the open source process of LLM, we highlight the open-sourced LLM mod
   ```yaml
   Field: Language
   Params: 70B
-  Training Data: 5.2TB (500B tokens)
+  Training Data: 5.2TB (1.4T tokens)
   Training petaFLOPs: 580M
   Architecture: De
   ```


### PR DESCRIPTION
Page 2 , last paragraph in Chinchila paper
> We verify this by training a more compute-optimal 70B model, called Chinchilla, on 1.4 trillion
tokens.